### PR TITLE
[WIFI-6170] Add OpenWifi Docker Compose deployment with PostgreSQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ COPY --from=builder /poco/cmake-build/lib/* /lib/
 
 COPY owls.properties.tmpl /
 COPY docker-entrypoint.sh /
+COPY wait-for-postgres.sh /
 RUN wget https://raw.githubusercontent.com/Telecominfraproject/wlan-cloud-ucentral-deploy/main/docker-compose/certs/restapi-ca.pem \
     -O /usr/local/share/ca-certificates/restapi-ca-selfsigned.pem
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN addgroup -S "$OWLS_USER" && \
 RUN mkdir /openwifi
 RUN mkdir -p "$OWLS_ROOT" "$OWLS_CONFIG" && \
     chown "$OWLS_USER": "$OWLS_ROOT" "$OWLS_CONFIG"
-RUN apk add --update --no-cache librdkafka mariadb-connector-c libpq unixodbc su-exec gettext ca-certificates bash jq curl
+RUN apk add --update --no-cache librdkafka mariadb-connector-c libpq unixodbc su-exec gettext ca-certificates bash jq curl postgresql-client
 
 COPY --from=builder /owls/cmake-build/owls /openwifi/owls
 COPY --from=builder /cppkafka/cmake-build/src/lib/* /lib/

--- a/wait-for-postgres.sh
+++ b/wait-for-postgres.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# wait-for-postgres.sh
+
+set -e
+  
+host="$1"
+shift
+
+export PGUSER=$(grep 'storage.type.postgresql.username' $OWLS_CONFIG/owls.properties | awk -F '= ' '{print $2}')
+export PGPASSWORD=$(grep 'storage.type.postgresql.password' $OWLS_CONFIG/owls.properties | awk -F '= ' '{print $2}')
+  
+until psql -h "$host" -c '\q'; do
+  >&2 echo "Postgres is unavailable - sleeping"
+  sleep 1
+done
+  
+>&2 echo "Postgres is up - executing command"
+
+if [ "$1" = '/openwifi/owls' -a "$(id -u)" = '0' ]; then
+    if [ "$RUN_CHOWN" = 'true' ]; then
+      chown -R "$OWLS_USER": "$OWLS_ROOT" "$OWLS_CONFIG"
+    fi
+    exec su-exec "$OWLS_USER" "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
The microservices only initialize the DB when it is available on startup. Since Docker Compose doesn't wait for the DB container to be ready that can lead to empty databases. This script can be used as a workaround to wait for DB readiness.